### PR TITLE
Adds dAPI fallback managers list to DapiFallbackV2

### DIFF
--- a/contracts/DapiFallbackV2.sol
+++ b/contracts/DapiFallbackV2.sol
@@ -11,9 +11,33 @@ import "./interfaces/IHashRegistry.sol";
 import "./interfaces/IDapiFallbackV2.sol";
 import "./interfaces/IDapiDataRegistry.sol";
 
-/// @title DapiFallbackV2 contract for handling dAPI fallbacks in case of primary data feed failure.
-/// @notice This contract contains the logic for executing dAPI fallbacks
-/// and ensuring data feed continuity by utilizing Merkle proofs for verification.
+/// @title Contract that sets dAPI names to fallback data feeds under specific
+/// conditions
+/// @notice The objective of this contract is to enable individual "dAPI
+/// fallback managers" to be able to execute a pre-planned response plan for
+/// dAPI emergencies. The plan is to redirect the dAPI from a more
+/// decentralized data feed that will not be able to respond to emergencies
+/// swiftly to a data feed that we can reasonably expect to not be affected by
+/// the factors that cause the emergency or at least quickly address these.
+/// The conditions to be able to execute the plan are as follow:
+/// - The sender must be a dAPI fallback manager
+/// - The respective fallback data feed must have been included in a Merkle
+/// tree whose root has been signed by all "root signers" and registered on the
+/// HashRegsitry contract.
+/// - The dAPI must have already been pointing to a data feed that is not the
+/// fallback data feed
+/// - Have enought funds to be able to top-up the data feed sponsor wallet for at
+/// least a day on the current chain according to the prices from the merkle tree
+/// In addition to executing fallbacks, the dAPI fallback managers are allowed
+/// to transfer funds from this contract to the sponsor wallets of the fallback
+/// data feeds (because both the fallback data feeds being operational and
+/// their sponsor wallets being funded are required for fallbacks to be
+/// executed). These manager can also undo the fallback execution by setting the
+/// dAPI back to a decentralized data feed.
+/// @dev This contract needs to be granted the dAPI name setter role by the
+/// manager of the respective Api3ServerV1 contract to be able to execute
+/// fallbacks. It also require the dAPI adder and dAPI remover roles from the
+/// DapiDataRegistry contract as well
 contract DapiFallbackV2 is Ownable, SelfMulticall, IDapiFallbackV2 {
     using EnumerableSet for EnumerableSet.Bytes32Set;
 

--- a/contracts/interfaces/IDapiFallbackV2.sol
+++ b/contracts/interfaces/IDapiFallbackV2.sol
@@ -1,41 +1,31 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.18;
 
-import "@api3/airnode-protocol-v1/contracts/access-control-registry/interfaces/IAccessControlRegistryAdminnedWithManager.sol";
+import "@api3/airnode-protocol-v1/contracts/utils/interfaces/ISelfMulticall.sol";
 
-/// @title IDapiFallbackV2 - Interface defining the contract for dAPI's fallback mechanisms.
-/// @notice This interface declares the events and functions required to manage and execute dAPI fallbacks.
-interface IDapiFallbackV2 is IAccessControlRegistryAdminnedWithManager {
-    /// @notice Defines the arguments required to execute a dAPI fallback.
-    /// These arguments include various parameters and Merkle proofs necessary for the fallback process.
+interface IDapiFallbackV2 is ISelfMulticall {
+    event SetDapiFallbackManagers(address[] dapiFallbackManagers);
+
     struct ExecuteDapiFallbackArgs {
-        bytes32 dapiName; /// Unique identifier for the dAPI.
-        bytes32 dataFeedId; /// Identifier for the data feed receiving the update.
-        bytes32 fallbackRoot; /// Root of the Merkle tree representing the dAPI's fallback structure.
-        bytes32[] fallbackProof; /// Merkle proof for validating the fallback parameters.
-        bytes updateParams; /// Encoded parameters necessary for updating the data feed.
-        bytes32 priceRoot; /// Root of the Merkle tree related to the pricing data.
-        bytes32[] priceProof; /// Merkle proof for verifying the updated pricing data.
-        uint256 duration; /// Time period for which the price is calculated.
-        uint256 price; /// Cost of the data feed for a given duration.
-        address payable sponsorWallet; /// Address of the sponsor wallet for funding.
+        uint256 dapiFallbackManagerInd; // dAPI fallback manager index
+        bytes32 dapiName; // Encoded bytes32 dAPI name
+        bytes32 dataFeedId; // Identifier for the data feed receiving the update
+        bytes32 fallbackRoot; // Root of the Merkle tree representing the dAPI's fallback structure
+        bytes32[] fallbackProof; // Merkle proof for validating the fallback parameters
+        bytes updateParams; // Encoded parameters necessary for updating the data feed
+        bytes32 priceRoot; // Root of the Merkle tree related to the pricing data
+        bytes32[] priceProof; // Merkle proof for verifying the updated pricing data
+        uint256 duration; // Time period for which the price is calculated
+        uint256 price; // Cost of the data feed for a given duration
+        address payable sponsorWallet; // Address of the sponsor wallet for funding
     }
 
-    /// @notice Event emitted when funds are successfully withdrawn.
-    /// @param recipient Address receiving the funds.
-    /// @param amount Amount of funds withdrawn.
-    /// @param remainingBalance Remaining balance after the withdrawal.
     event Withdrawn(
         address indexed recipient,
         uint256 amount,
         uint256 remainingBalance
     );
 
-    /// @notice Event emitted when a sponsor wallet is successfully funded.
-    /// @param sponsorWallet Address of the sponsor wallet that was funded.
-    /// @param amount Amount of funds added.
-    /// @param remainingBalance Remaining balance after funding.
-    /// @param sender Address of the party that initiated the funding.
     event FundedSponsorWallet(
         address indexed sponsorWallet,
         uint256 amount,
@@ -43,77 +33,38 @@ interface IDapiFallbackV2 is IAccessControlRegistryAdminnedWithManager {
         address sender
     );
 
-    /// @notice Event emitted when a dAPI fallback has been executed.
-    /// @param dapiName The unique identifier for the dAPI involved.
-    /// @param dataFeedId Identifier for the data feed that was updated.
-    /// @param sender Address of the party that initiated the fallback execution.
     event ExecutedDapiFallback(
         bytes32 indexed dapiName,
         bytes32 indexed dataFeedId,
         address sender
     );
 
-    /// @notice Event emitted when a dAPI fallback has been reverted.
-    /// @param dapiName The unique identifier for the dAPI involved.
-    /// @param dataFeedId Identifier for the data feed that was updated.
-    /// @param sponsorWallet Address of the account used to perform data feed
-    /// updates.
     event RevertedDapiFallback(
         bytes32 indexed dapiName,
         bytes32 indexed dataFeedId,
         address sponsorWallet
     );
 
-    function FALLBACK_EXECUTER_ROLE_DESCRIPTION()
-        external
-        view
-        returns (string memory);
-
-    function FALLBACK_REVERTER_ROLE_DESCRIPTION()
-        external
-        view
-        returns (string memory);
-
-    function fallbackExecuterRole() external view returns (bytes32);
-
-    function fallbackReverterRole() external view returns (bytes32);
-
-    /// @notice Returns the address of the Api3ServerV1 contract.
     function api3ServerV1() external view returns (address);
 
-    /// @notice Returns the address of the HashRegistry contract.
     function hashRegistry() external view returns (address);
 
-    /// @notice Returns the address of the DapiDataRegistry contract.
     function dapiDataRegistry() external view returns (address);
 
-    /// @notice Allows the contract owner to withdraw funds from the contract.
-    /// @param amount The amount of funds to withdraw.
-    /// @dev This function should emit the Withdrawn event after a successful withdrawal.
-    function withdraw(uint256 amount) external;
+    function setDapiFallbackManagers(
+        address[] calldata _dapiFallbackManagers
+    ) external;
 
-    /// @notice Executes the dAPI fallback mechanism.
-    /// @param args Structured data representing the fallback execution requirements.
-    /// @dev This function should emit the ExecutedDapiFallback event upon successful execution.
+    function withdraw(address payable recipient, uint256 amount) external;
+
+    function withdrawAll(address payable recipient) external;
+
     function executeDapiFallback(
         ExecuteDapiFallbackArgs calldata args
     ) external;
 
-    /// @notice Reverts the dAPI fallback execution mechanism.
-    /// @param dapiName dAPI name
-    /// @param dataFeedId Data feed ID the dAPI will point to
-    /// @param sponsorWallet Sponsor wallet address used to trigger updates
-    /// @param deviationThresholdInPercentage Value used to determine if data
-    /// feed requires updating based on deviation against API value
-    /// @param deviationReference Reference value that deviation will be
-    /// calculated against
-    /// @param heartbeatInterval Value used to determine if data
-    /// feed requires updating based on time elapsed since last update
-    /// @param root dAPI Management Merkle tree root hash
-    /// @param proof Array of hashes to verify a Merkle tree leaf
-    /// @dev This function should emit the RevertedDapiFallback event upon
-    /// successful execution and requires the caller to be the contract owner.
     function revertDapiFallback(
+        uint256 dapiFallbackManagerInd,
         bytes32 dapiName,
         bytes32 dataFeedId,
         address sponsorWallet,
@@ -124,10 +75,12 @@ interface IDapiFallbackV2 is IAccessControlRegistryAdminnedWithManager {
         bytes32[] calldata proof
     ) external;
 
-    /// @notice Returns the list of dAPIs for which fallback mechanism has been
-    /// exectued.
     function getFallbackedDapis()
         external
         view
         returns (bytes32[] memory dapis);
+
+    function dapiFallbackManagers(uint256) external view returns (address);
+
+    function getDapiFallbackManagers() external view returns (address[] memory);
 }


### PR DESCRIPTION
Closes #38 

### What does this PR changes:

* Realized that keeping track of 2 different lists of accounts that will most definitely contain the same accounts, doesn't make much sense so I ended up adding a single list of managers that will be allowed to execute and revert fallbacks (Same approach used by `DapiFallbackV1` with the `dapiFallbackExecutors` array).
* More tests and comments cleanup 
* Some minor fixes and refactor
