### PR TITLE
Use Data Feed ID as naming convention

### DIFF
--- a/frontend/pages/merkle-trees/dapi-fallback.tsx
+++ b/frontend/pages/merkle-trees/dapi-fallback.tsx
@@ -85,7 +85,7 @@ export default function DapiFallbackTree(props: Props) {
             <TableHeader sticky>
               <TableRow>
                 <TableHead>dAPI Name</TableHead>
-                <TableHead>Beacon ID</TableHead>
+                <TableHead>Data Feed ID</TableHead>
                 <TableHead>Sponsor Wallet Address</TableHead>
               </TableRow>
             </TableHeader>

--- a/frontend/pages/merkle-trees/dapi-management.tsx
+++ b/frontend/pages/merkle-trees/dapi-management.tsx
@@ -84,7 +84,7 @@ export default function DapiManagementTree(props: Props) {
             <TableHeader sticky>
               <TableRow>
                 <TableHead>dAPI Name</TableHead>
-                <TableHead>Beacon ID</TableHead>
+                <TableHead>Data Feed ID</TableHead>
                 <TableHead>Sponsor Wallet Address</TableHead>
               </TableRow>
             </TableHeader>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,14 +51,14 @@ This command constructs the Merkle tree based on the data, signs the root, and u
 
 - **Values**:
   - **dAPI Name (bytes32)**: The name of the dAPI, hashed.
-  - **Beacon Set ID (bytes32)**: Identifier for the beacon set.
+  - **Data Feed ID (bytes32)**: Identifier for the data feed.
   - **dAPI Sponsor Wallet Address (address)**: Wallet address of the dAPI sponsor wallet.
 
 ### 3. dAPI fallback Merkle Tree
 
 - **Values**:
   - **dAPI Name (bytes32)**: The name of the dAPI, hashed.
-  - **Beacon ID (bytes32)**: Identifier for the Beacon.
+  - **Data Feed ID (bytes32)**: Identifier for the data feed.
   - **Sponsor Wallet Address (address)**: Address of the sponsor wallet.
 
 ### 4. Signed API URL Merkle Tree


### PR DESCRIPTION
Closes #55 

Change all occurrences of `Beacon ID` and `Beacon Set ID` with the term `Data Feed ID`