### PR TITLE
Add github action to push data changes to the gh-pages branch

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,15 @@
+# GitHub Actions Workflow: Deploy to GitHub Pages
+
+This GitHub Actions workflow automates the process of deploying new files from the main branch to the gh-pages branch, updating the contents of a `data` folder.
+
+## Workflow Details
+
+- **Trigger:** The workflow is triggered on each push to the main branch.
+- **Job:** The workflow consists of a single job named `deploy`.
+- **Runner:** The job runs on the latest version of Ubuntu.
+
+When changes to the `gh-pages` branch are picked up, it will automatically start a new deploy a new update to github pages which can be accessed on:
+
+```
+https://api3dao.github.io/dapi-management/data/<merkle-tree-folder-path>/current-hash.json
+```

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,8 +1,8 @@
-# GitHub Actions Workflow: Deploy to GitHub Pages
+# github-pages.yml
 
-This GitHub Actions workflow automates the process of deploying new files from the main branch to the gh-pages branch, updating the contents of a `data` folder.
+This GitHub Actions workflow detects changes to the data folder on the main branch, and pushes those changes to the gh-pages branch.
 
-## Workflow Details
+## Details
 
 - **Trigger:** The workflow is triggered on each push to the main branch.
 - **Job:** The workflow consists of a single job named `deploy`.

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -22,10 +22,15 @@ jobs:
       run: |
         git checkout main -- data
 
-    - name: Commit and push changes
+    - name: Commit and push if there are changes
       run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        git add .
-        git commit -m "Update gh-pages with new files"
-        git push --set-upstream origin gh-pages
+        if [ -n "$(git status --porcelain)" ]; then
+          echo "Changes detected in gh-pages branch."
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m "Update gh-pages with new files"
+          git push --set-upstream origin gh-pages
+        else
+          echo "No changes to commit and push."
+        fi

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,31 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout main branch
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Checkout gh-pages branch
+      run: git checkout gh-pages
+
+    - name: Copy new files to data folder
+      run: |
+        git checkout main -- data
+
+    - name: Commit and push changes
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add .
+        git commit -m "Update gh-pages with new files"
+        git push --set-upstream origin gh-pages

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -29,8 +29,8 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .
-          git commit -m "Update gh-pages with new files"
-          git push --set-upstream origin gh-pages
+          git commit -m "Update data file(s)"
+          git push
         else
           echo "No changes to commit and push."
         fi


### PR DESCRIPTION
Closes #6 

`github-pages.yml` has been created to include new changes to the `data` folder into `gh-pages` branch. Which has been set up to deploy `gh-pages` to the github pages api. 

Steps include:

1.  Checkout main
2. Switch branch to `gh-pages`
3. checkout data folder on main into `gh-pages`
4. Commit and push if there are any changes

To access github pages one can navigate to:

`https://api3dao.github.io/dapi-management/data/<merkle-tree-path>/current-hash.json`

For example 
`https://api3dao.github.io/dapi-management/data/dapi-fallback-merkle-tree-root/current-hash.json`

## Current Github api page after this branch is merged it should automatically deploy github pages with the correct timestamp
<img width="1431" alt="image" src="https://github.com/api3dao/dapi-management/assets/46445845/1eacff0f-5127-4aa1-baee-2fa65ab23d34">

