### PR TITLE
Fix gh-pages action when it has empty changes

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -32,13 +32,13 @@ jobs:
 
     - name: Install dependencies
       run: |
-        if [ -n "$(git status data scripts/split-dapi-pricing.js)" ]; then
+        if [ -n "$(git status data scripts/split-dapi-pricing.js --porcelain)" ]; then
           yarn install --frozen-lockfile
         fi
 
     - name: Check if there are changes in gh-pages branch
       run: |
-        if [ -n "$(git status data scripts/split-dapi-pricing.js)" ]; then
+        if [ -n "$(git status data scripts/split-dapi-pricing.js --porcelain)" ]; then
           echo "Changes detected in gh-pages branch."
           git config user.name github-actions
           git config user.email github-actions@github.com


### PR DESCRIPTION
Update gh-action to not try commit and push if there are empty changes. 

![image](https://github.com/api3dao/dapi-management/assets/46445845/097948f3-8f1d-4ebf-b76b-09a74618f23b)
