### PR TITLE
Update github-pages workflow by separating out running script and git commit/push 

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,9 +12,10 @@ This GitHub Actions workflow detects changes to the data folder on the main bran
 
 Due to the size of `dapi-pricing` merkle tree values we need to split the values in separate files.
 The workflow will:
+
 1. Checkout the required files including the script that needs to split the values
 2. Install packages that is required in the script
-3. Run the script that splits the values in separate files 
+3. Run the script that splits the values in separate files
 4. Commit and push if there are changes to the data directory
 
 When changes to the `gh-pages` branch are picked up, it will automatically start a new deploy a new update to github pages which can be accessed on:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,6 +8,15 @@ This GitHub Actions workflow detects changes to the data folder on the main bran
 - **Job:** The workflow consists of a single job named `deploy`.
 - **Runner:** The job runs on the latest version of Ubuntu.
 
+## dApi Pricing
+
+Due to the size of `dapi-pricing` merkle tree values we need to split the values in separate files.
+The workflow will:
+1. Checkout the required files including the script that needs to split the values
+2. Install packages that is required in the script
+3. Run the script that splits the values in separate files 
+4. Commit and push if there are changes to the data directory
+
 When changes to the `gh-pages` branch are picked up, it will automatically start a new deploy a new update to github pages which can be accessed on:
 
 ```

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,17 +8,15 @@ This GitHub Actions workflow detects changes to the data folder on the main bran
 - **Job:** The workflow consists of a single job named `deploy`.
 - **Runner:** The job runs on the latest version of Ubuntu.
 
-## dApi Pricing
-
-Due to the size of `dapi-pricing` merkle tree values we need to split the values in separate files.
+Due to the size of `dapi-pricing` merkle tree values we need to split the values into separate files.
 The workflow will:
 
 1. Checkout the required files including the script that needs to split the values
-2. Install packages that is required in the script
-3. Run the script that splits the values in separate files
+2. Install packages in order for the split script to run
+3. Run the script that splits the values into separate files
 4. Commit and push if there are changes to the data directory
 
-When changes to the `gh-pages` branch are picked up, it will automatically start a new deploy a new update to github pages which can be accessed on:
+When changes to the `gh-pages` branch are picked up, it will automatically trigger a new deploy of gh-pages branch which can be accessed on:
 
 ```
 https://api3dao.github.io/dapi-management/data/<merkle-tree-folder-path>/current-hash.json

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Copy required files
       run: |
-        git checkout main -- data scripts package.json yarn.lock
+        git checkout main -- data scripts package.json yarn.lock .prettierrc.js
         echo "Unstage all files"
         git reset
 

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -32,20 +32,23 @@ jobs:
 
     - name: Install dependencies
       run: |
-        if [ -n "$(git status data scripts/split-dapi-pricing.js --porcelain)" ]; then
-          yarn install --frozen-lockfile
-        fi
+        yarn install --frozen-lockfile
 
-    - name: Check if there are changes in gh-pages branch
+    - name: Run split script
       run: |
-        if [ -n "$(git status data scripts/split-dapi-pricing.js --porcelain)" ]; then
+        echo "Running dapi pricing split script"
+        node scripts/split-dapi-pricing.js
+
+    - name: Commit and push if changes detected
+      run: |
+        if [ -n "$(git status data --porcelain)" ]; then
           echo "Changes detected in gh-pages branch."
           git config user.name github-actions
           git config user.email github-actions@github.com
-          echo "Running dapi pricing split script"
-          node scripts/split-dapi-pricing.js
           git add data
+          echo "Commiting file"
           git commit -m "Update data file(s)"
+          echo "Pushing commit"
           git push
         else
           echo "No changes to commit and push."

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -31,24 +31,19 @@ jobs:
         cache: 'yarn'
 
     - name: Install dependencies
-      run: |
-        yarn install --frozen-lockfile
+      run: yarn install --frozen-lockfile
 
-    - name: Run split script
-      run: |
-        echo "Running dapi pricing split script"
-        node scripts/split-dapi-pricing.js
+    - name: Run dapi pricing split script
+      run: node scripts/split-dapi-pricing.js
 
-    - name: Commit and push if changes detected
+    - name: Commit and push if changes are detected
       run: |
         if [ -n "$(git status data --porcelain)" ]; then
           echo "Changes detected in gh-pages branch."
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add data
-          echo "Commiting file"
           git commit -m "Update data file(s)"
-          echo "Pushing commit"
           git push
         else
           echo "No changes to commit and push."


### PR DESCRIPTION
Changes has been made to the `github-pages.yml` to facilitate only commit and push when there are actual files that need to be pushed to the branch.

Workflow follows like:
1. checkout gh-pages
2. checkout required files
3. install packages
4. run the script <- This step will always run to create all the possible changes before we decide to push
5. if there are changes to the data directory commit and push

There was also a mismatch of format with main and gh-pages branch. The `dapi-pricing` split script runs `yarn format` and without the config we have in main branch this created discrepancies with the data folder but after the formatter runs with the default config there are no changes detected.

Format currently on `gh-pages`
![image](https://github.com/api3dao/dapi-management/assets/46445845/3f13199e-6ecd-44a7-9ac7-e1da12176770)

Format currently on `main`
![image](https://github.com/api3dao/dapi-management/assets/46445845/fa1bc6f0-2834-43e3-aec8-348c68240011)
  